### PR TITLE
[2025-01-15] v1.2.0 release

### DIFF
--- a/backend/common/exceptions/api.exception.ts
+++ b/backend/common/exceptions/api.exception.ts
@@ -40,3 +40,16 @@ export class AlreadyCancelledException extends ApiException {
     super('이미 취소된 예약입니다', HttpStatus.BAD_REQUEST);
   }
 }
+export class OptimisticLockException extends ApiException {
+  constructor() {
+    super(
+      '다른 요청과 충돌이 발생했습니다. 다시 시도해주세요.',
+      HttpStatus.CONFLICT,
+    );
+  }
+}
+export class SlotNotFoundException extends ApiException {
+  constructor() {
+    super('슬롯을 찾을 수 없습니다', HttpStatus.NOT_FOUND);
+  }
+}

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [{ "include": "**/*.lua", "outDir": "dist/src" }],
+    "watchAssets": true
   }
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -85,8 +85,8 @@ async function main() {
       track: Track.WEB,
       applicationUnit: ApplicationUnit.TEAM,
       creatorId: adminUserId,
-      startTime: new Date('2026-01-15T14:00:00+09:00'),
-      endTime: new Date('2026-01-17T18:00:00+09:00'),
+      startTime: new Date('2026-01-01T00:00:00+09:00'),
+      endTime: new Date('2026-01-31T23:59:59+09:00'),
       slotSchema: {
         content: { label: '내용', type: 'string' },
         startTime: { label: '시작 시간', type: 'string' },
@@ -109,8 +109,8 @@ async function main() {
       track: Track.ANDROID,
       applicationUnit: ApplicationUnit.INDIVIDUAL,
       creatorId: adminUserId,
-      startTime: new Date('2026-01-22T10:00:00+09:00'),
-      endTime: new Date('2026-01-22T12:00:00+09:00'),
+      startTime: new Date('2026-03-01T00:00:00+09:00'),
+      endTime: new Date('2026-03-31T23:59:59+09:00'),
       slotSchema: {
         content: { label: '내용', type: 'string' },
         startTime: { label: '시작 시간', type: 'string' },
@@ -133,8 +133,8 @@ async function main() {
       track: Track.IOS,
       applicationUnit: ApplicationUnit.INDIVIDUAL,
       creatorId: adminUserId,
-      startTime: new Date('2026-01-28T13:00:00+09:00'),
-      endTime: new Date('2026-01-28T16:00:00+09:00'),
+      startTime: new Date('2026-04-01T00:00:00+09:00'),
+      endTime: new Date('2026-04-30T23:59:59+09:00'),
       slotSchema: {
         content: { label: '내용', type: 'string' },
         startTime: { label: '시작 시간', type: 'string' },

--- a/backend/scripts/create-test-event.ts
+++ b/backend/scripts/create-test-event.ts
@@ -1,0 +1,74 @@
+/**
+ * 테스트용 이벤트 생성 스크립트
+ *
+ * 사용법:
+ * 1. 브라우저에서 GitHub OAuth 로그인 (ADMIN 권한 필요)
+ * 2. 개발자 도구 > Application > Cookies에서 access_token 복사
+ * 3. 아래 TOKEN 값을 복사한 토큰으로 교체
+ * 4. 실행: npx ts-node scripts/create-test-event.ts
+ */
+
+const TOKEN = 'yourtoken'; // 브라우저에서 복사한 토큰
+const BASE_URL = 'http://localhost:80/api';
+
+async function createTestEvent() {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - 1000 * 60 * 60); // 1시간 전 (이미 시작됨)
+  const endTime = new Date(now.getTime() + 1000 * 60 * 60 * 24); // 24시간 후
+
+  const eventData = {
+    title: '동시성 테스트 이벤트',
+    description: '동시성 제어 테스트를 위한 이벤트입니다.',
+    track: 'COMMON',
+    applicationUnit: 'INDIVIDUAL',
+    startTime: startTime.toISOString(),
+    endTime: endTime.toISOString(),
+    slotSchema: {
+      type: 'test',
+      fields: ['time'],
+    },
+    slots: [
+      {
+        maxCapacity: 5, // 5명만 예약 가능 (동시성 테스트용)
+        extraInfo: {
+          time: '14:00-15:00',
+          location: '회의실 A',
+        },
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch(`${BASE_URL}/events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `access_token=${TOKEN}`,
+      },
+      body: JSON.stringify(eventData),
+    });
+
+    const data = await response.json();
+
+    if (response.ok) {
+      console.log('이벤트 생성 성공!');
+      console.log('');
+      console.log('생성된 이벤트:');
+      console.log(`  ID: ${data.id}`);
+      console.log(`  제목: ${data.title}`);
+      console.log('');
+      console.log('생성된 슬롯:');
+      data.slots?.forEach((slot: { id: number; maxCapacity: number }) => {
+        console.log(`  슬롯 ID: ${slot.id} (정원: ${slot.maxCapacity}명)`);
+      });
+      console.log('');
+      console.log('이 슬롯 ID를 test-concurrency.ts의 SLOT_ID에 입력하세요.');
+    } else {
+      console.error('이벤트 생성 실패:', data);
+    }
+  } catch (error) {
+    console.error('오류 발생:', error);
+  }
+}
+
+createTestEvent();

--- a/backend/scripts/test-concurrency.ts
+++ b/backend/scripts/test-concurrency.ts
@@ -1,0 +1,115 @@
+/**
+ * 동시성 제어 테스트 스크립트
+ *
+ * 사용법:
+ * 1. 브라우저에서 GitHub OAuth 로그인
+ * 2. 개발자 도구 > Application > Cookies에서 access_token 복사
+ * 3. 아래 TOKEN 값을 복사한 토큰으로 교체
+ * 4. SLOT_ID를 테스트할 슬롯 ID로 교체
+ * 5. 실행: npx ts-node scripts/test-concurrency.ts
+ */
+
+const TOKEN = 'yourtoken';
+const SLOT_ID = 3; // 테스트할 슬롯 ID
+const CONCURRENT_REQUESTS = 10; // 동시 요청 수
+const BASE_URL = 'http://localhost:80/api';
+
+interface ReservationResponse {
+  status: string;
+  message: string;
+  jobId?: string;
+  reservation?: {
+    id: number;
+    slotId: number;
+    status: string;
+  };
+}
+
+async function makeReservation(requestId: number): Promise<{
+  requestId: number;
+  success: boolean;
+  data?: ReservationResponse;
+  error?: string;
+}> {
+  try {
+    const response = await fetch(`${BASE_URL}/reservations`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `access_token=${TOKEN}`,
+      },
+      body: JSON.stringify({ slotId: SLOT_ID }),
+    });
+
+    const data = await response.json();
+
+    return {
+      requestId,
+      success: response.ok,
+      data,
+    };
+  } catch (error) {
+    return {
+      requestId,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function runConcurrencyTest() {
+  console.log('='.repeat(60));
+  console.log('동시성 제어 테스트 시작');
+  console.log('='.repeat(60));
+  console.log(`슬롯 ID: ${SLOT_ID}`);
+  console.log(`동시 요청 수: ${CONCURRENT_REQUESTS}`);
+  console.log('');
+
+  // 동시에 요청 전송
+  const startTime = Date.now();
+  const promises = Array.from({ length: CONCURRENT_REQUESTS }, (_, i) =>
+    makeReservation(i + 1),
+  );
+
+  const results = await Promise.all(promises);
+  const endTime = Date.now();
+
+  // 결과 분석
+  const successCount = results.filter((r) => r.success).length;
+  const failCount = results.filter((r) => !r.success).length;
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('테스트 결과');
+  console.log('='.repeat(60));
+  console.log(`총 요청: ${CONCURRENT_REQUESTS}`);
+  console.log(`성공: ${successCount}`);
+  console.log(`실패: ${failCount}`);
+  console.log(`소요 시간: ${endTime - startTime}ms`);
+  console.log('');
+
+  // 상세 결과
+  console.log('상세 결과:');
+  results.forEach((result) => {
+    const status = result.success ? '✓' : '✗';
+    const message = result.data?.message || result.error || 'Unknown';
+    console.log(`  [${status}] 요청 #${result.requestId}: ${message}`);
+  });
+
+  // 중복 예약 확인
+  const queuedCount = results.filter((r) => r.data?.status === 'queued').length;
+  const duplicateCount = results.filter((r) =>
+    r.data?.message?.includes('이미'),
+  ).length;
+  const capacityFullCount = results.filter((r) =>
+    r.data?.message?.includes('마감'),
+  ).length;
+
+  console.log('');
+  console.log('분석:');
+  console.log(`  - 큐에 등록됨: ${queuedCount}`);
+  console.log(`  - 중복 예약 차단: ${duplicateCount}`);
+  console.log(`  - 정원 마감: ${capacityFullCount}`);
+}
+
+runConcurrencyTest().catch(console.error);

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,19 +3,33 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './prisma/prisma.module';
 import { EventsModule } from './events/events.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ReservationsModule } from './reservations/reservations.module';
 import { EventSlotsModule } from './event-slots/event-slots.module';
 import { AuthModule } from './auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
+import { RedisModule } from './redis/redis.module';
+import { BullModule } from '@nestjs/bullmq';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        connection: {
+          host: configService.get<string>('REDIS_HOST', 'localhost'),
+          port: configService.get<number>('REDIS_PORT', 6379),
+          password: configService.get<string>('REDIS_PASSWORD'),
+        },
+      }),
+      inject: [ConfigService],
+    }),
     PrismaModule,
+    RedisModule,
     EventsModule,
     ReservationsModule,
     EventSlotsModule,

--- a/backend/src/events/events.service.spec.ts
+++ b/backend/src/events/events.service.spec.ts
@@ -2,20 +2,30 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { EventsService } from './events.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { RedisService } from '../redis/redis.service';
 import { createPrismaMock } from '../test/mocks/prisma.mock';
 import { ApplicationUnit, Track } from '@prisma/client';
+
+const createRedisMock = () => ({
+  initStock: jest.fn().mockResolvedValue(undefined),
+  decrementStock: jest.fn().mockResolvedValue(true),
+  incrementStock: jest.fn().mockResolvedValue(undefined),
+});
 
 describe('EventsService', () => {
   let service: EventsService;
   let prismaMock: ReturnType<typeof createPrismaMock>;
+  let redisMock: ReturnType<typeof createRedisMock>;
 
   beforeEach(async () => {
     prismaMock = createPrismaMock();
+    redisMock = createRedisMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventsService,
         { provide: PrismaService, useValue: prismaMock },
+        { provide: RedisService, useValue: redisMock },
       ],
     }).compile();
 

--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
+import { StockSyncService } from './stock-sync.service';
+
+@Global()
+@Module({
+  providers: [RedisService, StockSyncService],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/backend/src/redis/redis.service.ts
+++ b/backend/src/redis/redis.service.ts
@@ -1,0 +1,149 @@
+import {
+  Injectable,
+  OnModuleDestroy,
+  OnModuleInit,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private client: Redis;
+  private readonly logger = new Logger(RedisService.name);
+
+  // Lua 스크립트 캐시 (SHA 해시)
+  private scripts: {
+    decrementStock?: string;
+    incrementStock?: string;
+    initStock?: string;
+  } = {};
+
+  constructor(private configService: ConfigService) {}
+
+  async onModuleInit() {
+    this.client = new Redis({
+      host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+      port: this.configService.get<number>('REDIS_PORT', 6379),
+      password: this.configService.get<string>('REDIS_PASSWORD'),
+    });
+
+    this.client.on('error', (err) => {
+      this.logger.error('Redis connection error:', err);
+    });
+
+    this.client.on('connect', () => {
+      this.logger.log('Redis connected');
+    });
+
+    // lua script 로드
+    await this.loadScripts();
+  }
+
+  onModuleDestroy() {
+    this.client.disconnect();
+  }
+
+  getClient(): Redis {
+    return this.client;
+  }
+
+  getStockKey(slotId: number): string {
+    return `slot:${slotId}:stock`;
+  }
+
+  // Lua 스크립트 파일 로드 및 Redis에 등록
+  private async loadScripts() {
+    const scriptsDir = path.join(__dirname, 'scripts');
+
+    const decrementScript = fs.readFileSync(
+      path.join(scriptsDir, 'decrement-stock.lua'),
+      'utf-8',
+    );
+    const incrementScript = fs.readFileSync(
+      path.join(scriptsDir, 'increment-stock.lua'),
+      'utf-8',
+    );
+    const initScript = fs.readFileSync(
+      path.join(scriptsDir, 'init-stock.lua'),
+      'utf-8',
+    );
+
+    // SCRIPT LOAD로 Redis에 등록하고 SHA 해시 저장
+    this.scripts.decrementStock = (await this.client.script(
+      'LOAD',
+      decrementScript,
+    )) as string;
+
+    this.scripts.incrementStock = (await this.client.script(
+      'LOAD',
+      incrementScript,
+    )) as string;
+
+    this.scripts.initStock = (await this.client.script(
+      'LOAD',
+      initScript,
+    )) as string;
+
+    this.logger.log('Lua scripts loaded');
+  }
+
+  async syncAllStocks(
+    // 서버 시작 시 모든 슬롯 재고 동기화
+    slots: { id: number; maxCapacity: number; currentCount: number }[],
+  ): Promise<void> {
+    for (const slot of slots) {
+      await this.initStock(slot.id, slot.maxCapacity, slot.currentCount);
+    }
+    this.logger.log(` ${slots.length} 슬롯 재고를 Redis에 동기화 했습니다.`);
+  }
+
+  // 재고 차감 (예약 신청 시)
+  async decrementStock(slotId: number): Promise<boolean> {
+    const key = this.getStockKey(slotId);
+    const result = await this.client.evalsha(
+      this.scripts.decrementStock!,
+      1,
+      key,
+    );
+    return result === 1;
+  }
+
+  // 재고 복구 (예약 실패/취소 시)
+  async incrementStock(slotId: number, maxCapacity: number): Promise<number> {
+    const key = this.getStockKey(slotId);
+    const result = await this.client.evalsha(
+      this.scripts.incrementStock!,
+      1,
+      key,
+      maxCapacity,
+    );
+    return result as number;
+  }
+
+  // 재고 초기화 (이벤트 생성 또는 서버 시작 시)
+  async initStock(
+    slotId: number,
+    maxCapacity: number,
+    currentCount: number,
+  ): Promise<number> {
+    const key = this.getStockKey(slotId);
+    const result = await this.client.evalsha(
+      this.scripts.initStock!,
+      1,
+      key,
+      maxCapacity,
+      currentCount,
+    );
+    return result as number;
+  }
+
+  // 현재 재고 조회 (추후 디버깅/모니터링용)
+  async getStock(slotId: number): Promise<number> {
+    const key = this.getStockKey(slotId);
+    const result = await this.client.get(key);
+    return result ? parseInt(result, 10) : 0;
+  }
+}

--- a/backend/src/redis/scripts/decrement-stock.lua
+++ b/backend/src/redis/scripts/decrement-stock.lua
@@ -1,0 +1,12 @@
+local current = tonumber(redis.call('GET', KEYS[1]))
+
+if current and current > 0 then
+    redis.call('DECR', KEYS[1])
+    return 1
+end
+
+return 0
+
+-- 재고 차감 스크립트
+-- KEYS[1]: 슬롯 재고 키 (예: "slot:123:stock")
+-- 반환: 1(성공), 0(재고 부족)

--- a/backend/src/redis/scripts/increment-stock.lua
+++ b/backend/src/redis/scripts/increment-stock.lua
@@ -1,0 +1,13 @@
+local current = tonumber(redis.call('GET', KEYS[1])) or 0
+local maxStock = tonumber(ARGV[1])
+
+if current < maxStock then
+    return redis.call('INCR', KEYS[1])
+end
+
+return current
+
+-- 재고 복구 스크립트 (보상 트랜잭션용)
+-- KEYS[1]: 슬롯 재고 키
+-- ARGV[1]: 최대 재고 (초과 방지용)
+-- 반환: 복구 후 재고 수량

--- a/backend/src/redis/scripts/init-stock.lua
+++ b/backend/src/redis/scripts/init-stock.lua
@@ -1,0 +1,13 @@
+local maxCapacity = tonumber(ARGV[1])
+local currentCount = tonumber(ARGV[2])
+local remaining = maxCapacity - currentCount
+
+redis.call('SET', KEYS[1], remaining)
+
+return remaining
+
+-- 재고 초기화 스크립트
+-- KEYS[1]: 슬롯 재고 키
+-- ARGV[1]: 최대 정원
+-- ARGV[2]: 현재 예약 수
+-- 반환: 설정된 남은 재고

--- a/backend/src/redis/stock-sync.service.ts
+++ b/backend/src/redis/stock-sync.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { RedisService } from '../redis/redis.service';
+
+@Injectable()
+export class StockSyncService implements OnModuleInit {
+  private readonly logger = new Logger(StockSyncService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async onModuleInit() {
+    await this.syncAllStocks();
+  }
+
+  async syncAllStocks(): Promise<void> {
+    this.logger.log('Starting stock synchronization...');
+
+    const slots = await this.prisma.eventSlot.findMany({
+      select: {
+        id: true,
+        maxCapacity: true,
+        currentCount: true,
+      },
+    });
+
+    for (const slot of slots) {
+      await this.redisService.initStock(
+        slot.id,
+        slot.maxCapacity,
+        slot.currentCount,
+      );
+    }
+
+    this.logger.log(`Synchronized ${slots.length} slots to Redis`);
+  }
+}

--- a/backend/src/reservations/dto/reservation-job.dto.ts
+++ b/backend/src/reservations/dto/reservation-job.dto.ts
@@ -1,0 +1,8 @@
+export interface ReservationJobData {
+  userId: string;
+  slotId: number;
+  maxCapacity: number; // Redis 복구 시 사용
+}
+
+export const RESERVATION_QUEUE = 'reservation-queue';
+export const PROCESS_RESERVATION_JOB = 'process-reservation';

--- a/backend/src/reservations/reservations.controller.ts
+++ b/backend/src/reservations/reservations.controller.ts
@@ -49,12 +49,7 @@ export class ReservationsController {
     @CurrentUser('id') userId: string,
     @Body() applyReservationDto: ApplyReservationDto,
   ) {
-    const reservation = await this.reservationsService.apply(
-      userId,
-      applyReservationDto,
-    );
-
-    return new ReservationResponseDto(reservation);
+    return this.reservationsService.apply(userId, applyReservationDto);
   }
 
   @Get()

--- a/backend/src/reservations/reservations.module.ts
+++ b/backend/src/reservations/reservations.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
 import { ReservationsService } from './reservations.service';
 import { ReservationsController } from './reservations.controller';
+import { ReservationsProcessor } from './reservations.processor';
+import { RESERVATION_QUEUE } from './dto/reservation-job.dto';
 
 @Module({
+  imports: [
+    BullModule.registerQueue({
+      name: RESERVATION_QUEUE,
+    }),
+  ],
   controllers: [ReservationsController],
-  providers: [ReservationsService],
+  providers: [ReservationsService, ReservationsProcessor],
 })
 export class ReservationsModule {}

--- a/backend/src/reservations/reservations.processor.ts
+++ b/backend/src/reservations/reservations.processor.ts
@@ -1,0 +1,118 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { PrismaService } from '../prisma/prisma.service';
+import { RedisService } from '../redis/redis.service';
+import {
+  ReservationJobData,
+  RESERVATION_QUEUE,
+  PROCESS_RESERVATION_JOB,
+} from './dto/reservation-job.dto';
+import {
+  SlotFullException,
+  DuplicateReservationException,
+  OptimisticLockException,
+  SlotNotFoundException,
+} from '../../common/exceptions/api.exception';
+
+@Processor(RESERVATION_QUEUE)
+export class ReservationsProcessor extends WorkerHost {
+  private readonly logger = new Logger(ReservationsProcessor.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redisService: RedisService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<ReservationJobData>): Promise<void> {
+    if (job.name !== PROCESS_RESERVATION_JOB) {
+      this.logger.warn(`확인되지 않은 job: ${job.name}`);
+      return;
+    }
+
+    const { userId, slotId, maxCapacity } = job.data;
+    this.logger.log(`예약 진행중: userId=${userId}, slotId=${slotId}`);
+
+    try {
+      await this.processReservation(userId, slotId);
+      this.logger.log(`예약 확인: userId=${userId}, slotId=${slotId}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`예약 실패: ${message}`);
+
+      // 보상 트랜잭션: Redis 재고 복구
+      await this.redisService.incrementStock(slotId, maxCapacity);
+      this.logger.log(`slotId=${slotId} 의 재고 복구`);
+
+      throw error; // BullMQ가 재시도 또는 실패 처리
+    }
+  }
+
+  private async processReservation(
+    userId: string,
+    slotId: number,
+  ): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      // 슬롯(정원) 조회
+      const slot = await tx.eventSlot.findUnique({
+        where: { id: slotId },
+      });
+
+      if (!slot) {
+        throw new SlotNotFoundException();
+      }
+
+      // 낙관적 락으로 슬롯 업데이트
+      const updated = await tx.eventSlot.updateMany({
+        where: {
+          id: slotId,
+          version: slot.version,
+          currentCount: { lt: slot.maxCapacity },
+        },
+        data: {
+          currentCount: { increment: 1 },
+          version: { increment: 1 }, // 버전 관리
+        },
+      });
+
+      // 업데이트 실패 시 (version 불일치 또는 정원 초과)
+      if (updated.count === 0) {
+        const currentSlot = await tx.eventSlot.findUnique({
+          where: { id: slotId },
+        });
+
+        if (
+          currentSlot &&
+          currentSlot.currentCount >= currentSlot.maxCapacity
+        ) {
+          throw new SlotFullException();
+        }
+        throw new OptimisticLockException();
+      }
+
+      //  중복 예약 체크
+      const existing = await tx.reservation.findFirst({
+        where: {
+          userId,
+          slotId,
+          status: { in: ['PENDING', 'CONFIRMED'] },
+        },
+      });
+
+      if (existing) {
+        throw new DuplicateReservationException();
+      }
+
+      // 예약 생성
+      await tx.reservation.create({
+        data: {
+          userId,
+          slotId,
+          status: 'CONFIRMED',
+        },
+      });
+    });
+  }
+}

--- a/backend/src/test/mocks/prisma.mock.ts
+++ b/backend/src/test/mocks/prisma.mock.ts
@@ -51,6 +51,7 @@ export const createTxMock = () => ({
   eventSlot: {
     findUnique: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
   },
   reservation: {
     findFirst: jest.fn(),

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,9 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - WATCHPACK_POLLING=true
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redis123} # 추후 Redis 설정  다듬으면서 수정 필요할 수도 있음
     volumes:
       - ./backend:/app/backend
       - ./package.json:/app/package.json:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       --appendonly yes
       --appendfsync everysec
       --maxmemory ${REDIS_MAX_MEMORY:-256mb}
-      --maxmemory-policy ${REDIS_EVICTION_POLICY:-allkeys-lru}
+      --maxmemory-policy ${REDIS_EVICTION_POLICY:-noeviction}
       --requirepass ${REDIS_PASSWORD:-redis123}
     volumes:
       - redis-data:/data

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
-  - 'frontend'
-  - 'backend'
+  - frontend
+  - backend
+
+ignoredBuiltDependencies:
+  - '@nestjs/core'
+  - '@prisma/engines'
+  - '@scarf/scarf'
+  - bcrypt
+  - esbuild
+  - msgpackr-extract
+  - prisma
+  - unrs-resolver


### PR DESCRIPTION
# v1.2.0 (2026년 1월 15일)

이번 릴리즈에는 대규모 동시 예약 처리를 위한 동시성 제어 시스템이 포함되어 있습니다.

## Highlights

- **Redis 기반 동시성 제어**: Lua Script를 활용한 원자적 재고 관리로 race condition 방지
- **BullMQ 비동기 처리**: Job Queue 기반 예약 처리로 빠른 응답과 안정적인 백그라운드 처리
- **PostgreSQL 낙관적 락**: version 필드를 활용한 DB 레벨 동시성 제어
- **보상 트랜잭션**: 예약 실패 시 Redis 재고 자동 복구
- **재고 동기화**: 서버 시작 시 DB-Redis 간 자동 동기화

<br>

## Backend

### Redis Module

- Redis 모듈 전역 등록 (`RedisModule`, `RedisService`)
- IoRedis 클라이언트 기반 연결 관리
- Lua Script SHA 해시 캐싱으로 성능 최적화
- 환경변수 기반 Redis 연결 설정 (`REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`)
- 재고 키 형식: `slot:{slotId}:stock`

### Lua Scripts

- `decrement-stock.lua`: 예약 시 원자적 재고 차감
  - 재고 확인 후 차감까지 단일 원자적 연산
  - 정원 초과 방지
- `increment-stock.lua`: 취소/실패 시 재고 복구
  - 최대 정원 초과 방지 로직 포함
- `init-stock.lua`: 재고 초기화
  - 남은 재고 계산: maxCapacity - currentCount

### BullMQ Integration

- BullMQ 전역 설정 (`BullModule.forRootAsync`)
- 예약 전용 큐 등록 (`reservation-queue`)
- `ReservationsProcessor`: Job Consumer로 DB 트랜잭션 처리
- 실패 시 보상 트랜잭션으로 Redis 재고 자동 복구
- BullMQ 재시도 메커니즘 활용

### Reservations

- 예약 신청 (`POST /reservations`):
  - Redis 재고 즉시 차감 → Queue에 Job 추가 → 즉시 응답
  - 응답 상태: `PENDING` (비동기 처리 중)
- 예약 취소 (`DELETE /reservations/:id`):
  - Prisma 트랜잭션 내 낙관적 락 적용
  - 트랜잭션 성공 후 Redis 재고 복구
- Processor 내 예약 처리:
  - 낙관적 락으로 슬롯 업데이트
  - 중복 예약 체크
  - 최종 상태: `CONFIRMED`

### Optimistic Lock

- EventSlot 모델에 `version` 필드 추가
- 읽기 시점 version과 업데이트 시점 version 비교
- 버전 불일치 시 충돌 감지 및 예외 발생

### Stock Sync

- `StockSyncService`: 서버 시작 시 모든 슬롯 DB → Redis 동기화
- `onModuleInit()` 훅으로 자동 실행
- 이벤트 생성 시 슬롯 재고 Redis 초기화

### Error Handling

- `OptimisticLockException` 추가 (409 Conflict)
  - 메시지: "다른 요청과 충돌이 발생했습니다. 다시 시도해주세요."
- `SlotNotFoundException` 추가 (404 Not Found)
  - 메시지: "슬롯을 찾을 수 없습니다"

<br>

## Database

### Schema Changes

- `EventSlot.version`: 낙관적 락용 버전 필드 추가 (`Int @default(0)`)

<br>

## Infrastructure

### Docker

- Redis 서비스 추가 (`redis:8.4.0-alpine3.22`)
- AOF 영속성 활성화 (`appendonly yes`, `appendfsync everysec`)
- Eviction Policy `noeviction` 설정 (BullMQ Job 삭제 방지)
- 메모리 제한 설정 (`maxmemory 256mb`)
- 패스워드 인증 (`requirepass`)
- Backend 환경변수 추가 (`REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`)
- Backend → Redis 의존성 설정 (`depends_on`)
- Redis 데이터 볼륨 추가 (`redis-data`)
- 헬스체크 설정 (`redis-cli ping`)

<br>

## Breaking Changes

- 예약 API 응답이 즉시 `CONFIRMED` 대신 `PENDING` 상태 반환
- 클라이언트는 예약 확정까지 상태 확인 필요

<br>

## Known Limitations

- Redis 서버 다운 시 예약 불가 (Redis 의존성)
- 단일 Redis 인스턴스 구조 (클러스터 미지원)
