### PR TITLE
fix: QueueCleanupProcessor의 순환 참조 에러 해결

### DIFF
--- a/backend/src/queue/queue-cleanup-processor.ts
+++ b/backend/src/queue/queue-cleanup-processor.ts
@@ -1,9 +1,7 @@
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { QueueService } from './queue.service';
-
-export const QUEUE_CLEANUP_QUEUE = 'queue-cleanup';
-export const CLEANUP_JOB = 'cleanup-inactive-users';
+import { QUEUE_CLEANUP_QUEUE } from './queue.constants';
 
 export interface CleanupJobData {
   eventId: number;

--- a/backend/src/queue/queue.constants.ts
+++ b/backend/src/queue/queue.constants.ts
@@ -1,0 +1,3 @@
+export const QUEUE_CLEANUP_QUEUE = 'queue-cleanup';
+export const CLEANUP_JOB = 'cleanup-inactive-users';
+export interface CleanupJobData { eventId: number; }

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -3,10 +3,8 @@ import { BullModule } from '@nestjs/bullmq';
 import { QueueService } from './queue.service';
 import { QueueController } from './queue.controller';
 import { QueueTokenGuard } from './guards/queue-token.guard';
-import {
-  QueueCleanupProcessor,
-  QUEUE_CLEANUP_QUEUE,
-} from './queue-cleanup-processor';
+import { QueueCleanupProcessor } from './queue-cleanup-processor';
+import { QUEUE_CLEANUP_QUEUE } from './queue.constants';
 
 @Module({
   imports: [

--- a/backend/src/queue/queue.service.ts
+++ b/backend/src/queue/queue.service.ts
@@ -3,11 +3,8 @@ import { RedisService } from '../redis/redis.service';
 import { randomUUID } from 'crypto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
-import {
-  QUEUE_CLEANUP_QUEUE,
-  CLEANUP_JOB,
-  CleanupJobData,
-} from './queue-cleanup-processor';
+import { CleanupJobData } from './queue-cleanup-processor';
+import { CLEANUP_JOB, QUEUE_CLEANUP_QUEUE } from './queue.constants';
 
 @Injectable()
 export class QueueService {


### PR DESCRIPTION


## PR 유형
- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  UI 변경(스타일 파일 추가 및 수정 등)
- [ ]  문서 작성 및 수정
- [ ]  테스트 코드 추가
- [ ]  코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [ ]  기타 (설정 추가 등)




## 완료 작업 목록
- `queue.constants.ts` 파일을 생성하여 큐 관련 상수 및 인터페이스 분리

- `QueueService`와 `QueueCleanupProcessor` 간의 상호 참조(Circular Dependency) 구조 개선

- NestJS 앱 기동 시 발생하던 UndefinedDependencyException 에러 해결

## 변경 사항 상세
- 문제 원인: `QueueCleanupProcessor`가 `QueueService`를 주입받고, 동시에 `QueueService`가 프로세서 파일에 정의된 상수를 참조하면서 런타임에 의존성을 해결하지 못하는 문제가 있었습니다.

- 해결 방법: 두 클래스가 공통으로 사용하는 상수와 인터페이스를 별도의 상수 파일로 추출하여 참조 고리를 끊었습니다.



