### PR TITLE
hotfix: SlotList 필드 순서에 eventDate 추가

### DIFF
--- a/frontend/src/pages/event-detail/components/SlotList.tsx
+++ b/frontend/src/pages/event-detail/components/SlotList.tsx
@@ -19,7 +19,8 @@ interface SlotListProps {
 // 필드 표시 순서 정의 (id 기반)
 const FIELD_ORDER = [
   'content',      // 내용
-  'date',         // 날짜
+  'date',         // 날짜 (대체 id)
+  'eventDate',    // 날짜
   'startTime',    // 시작 시간
   'endTime',      // 종료 시간
   'location',     // 장소


### PR DESCRIPTION
## PR 유형
- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  UI 변경(스타일 파일 추가 및 수정 등)
- [ ]  문서 작성 및 수정
- [ ]  테스트 코드 추가
- [ ]  코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [ ]  기타 (설정 추가 등)

<br>

## 완료 작업 목록
- 이벤트 상세 페이지 슬롯 목록의 필드 컬럼 순서 수정
- SlotList 컴포넌트의 FIELD_ORDER에 `eventDate` 필드 ID 추가

<br>

## 주요 고민과 해결 과정

**문제 상황**

배포 환경에서 슬롯 목록의 컬럼 순서가 잘못 표시되는 문제가 발생했습니다.

- 기존 표시 순서: 내용 → 시작 시간 → 종료 시간 → 장소 → 멘토명 → 행사 날짜
- 기대 표시 순서: 내용 → 행사 날짜 → 시작 시간 → 종료 시간 → 장소 → 멘토명

**원인 분석**

SlotList 컴포넌트의 `FIELD_ORDER` 배열에 날짜 필드 ID로 `date`만 정의되어 있었습니다. 하지만 배포 DB의 slotSchema를 확인한 결과, 실제 날짜 필드 ID는 `eventDate`였습니다.

`eventDate`가 FIELD_ORDER에 없어서 정렬 시 맨 뒤로 배치되는 문제였습니다.

**해결 방법**

SlotList.tsx의 FIELD_ORDER 배열에 `eventDate`를 `startTime` 앞에 추가하여 올바른 순서로 정렬되도록 수정했습니다.