### PR TITLE
 perf: 예약 폴링 Redis 캐시 적용 및 Race Condition 보상 트랜잭션 수정 

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Event {
   notifications EventNotification[]
 
   @@index([organizationId])
+  @@index([organizationId, track])
 }
 
 model EventSlot {
@@ -88,6 +89,7 @@ model Reservation {
   slot EventSlot @relation(fields: [slotId], references: [id])
 
   @@index([slotId, groupNumber])
+  @@index([slotId, status])
   @@index([userId, status])
   @@index([userId, slotId, status])
 }

--- a/backend/src/redis/redis.service.ts
+++ b/backend/src/redis/redis.service.ts
@@ -188,4 +188,33 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     const result = await this.client.get(key);
     return result ? parseInt(result, 10) : 0;
   }
+
+  // 이벤트 예약자 명단 캐시 키
+  private getReserversKey(eventId: number): string {
+    return `event:${eventId}:reservers`;
+  }
+
+  // 예약자 명단 캐시 조회
+  async getReserversCache(eventId: number): Promise<string | null> {
+    return this.client.get(this.getReserversKey(eventId));
+  }
+
+  // 예약자 명단 캐시 저장 (TTL 60초)
+  async setReserversCache(
+    eventId: number,
+    data: string,
+    ttlSeconds = 60,
+  ): Promise<void> {
+    await this.client.set(
+      this.getReserversKey(eventId),
+      data,
+      'EX',
+      ttlSeconds,
+    );
+  }
+
+  // 예약자 명단 캐시 무효화
+  async invalidateReserversCache(eventId: number): Promise<void> {
+    await this.client.del(this.getReserversKey(eventId));
+  }
 }

--- a/backend/src/reservations/dto/reservation-job.dto.ts
+++ b/backend/src/reservations/dto/reservation-job.dto.ts
@@ -2,6 +2,7 @@ export interface ReservationJobData {
   reservationId: number;
   userId: string;
   slotId: number;
+  eventId: number;
   maxCapacity: number; // Redis 복구 시 사용
   stockDeducted: boolean;
   groupNumber: number | null;

--- a/backend/src/reservations/reservations.processor.spec.ts
+++ b/backend/src/reservations/reservations.processor.spec.ts
@@ -22,6 +22,7 @@ const createRedisMock = () => ({
   decrementStock: jest.fn().mockResolvedValue(true),
   initStock: jest.fn().mockResolvedValue(undefined),
   getStock: jest.fn().mockResolvedValue(10),
+  invalidateReserversCache: jest.fn().mockResolvedValue(undefined),
 });
 
 const createMetricsMock = () => ({
@@ -72,10 +73,12 @@ describe('ReservationsProcessor', () => {
     const slotId = 1;
     const maxCapacity = 10;
     const reservationId = 1;
+    const eventId = 1;
     const baseJobData: ReservationJobData = {
       reservationId,
       userId,
       slotId,
+      eventId,
       maxCapacity,
       stockDeducted: true,
       groupNumber: null,

--- a/backend/src/reservations/reservations.processor.ts
+++ b/backend/src/reservations/reservations.processor.ts
@@ -39,6 +39,7 @@ export class ReservationsProcessor extends WorkerHost {
       reservationId,
       userId,
       slotId,
+      eventId,
       maxCapacity,
       stockDeducted,
       groupNumber,
@@ -52,6 +53,9 @@ export class ReservationsProcessor extends WorkerHost {
     try {
       await this.processReservation(reservationId, userId, slotId, groupNumber);
       this.logger.log(`예약 확정: userId=${userId}, slotId=${slotId}`);
+
+      // 예약자 명단 캐시 무효화
+      await this.redisService.invalidateReserversCache(eventId);
 
       // 성공 메트릭
       this.metricsService.recordQueueJobComplete(

--- a/backend/src/reservations/reservations.service.spec.ts
+++ b/backend/src/reservations/reservations.service.spec.ts
@@ -20,6 +20,7 @@ const createRedisMock = () => ({
   initStock: jest.fn().mockResolvedValue(undefined),
   decrementStock: jest.fn().mockResolvedValue(true),
   incrementStock: jest.fn().mockResolvedValue(undefined),
+  invalidateReserversCache: jest.fn().mockResolvedValue(undefined),
 });
 
 const createQueueMock = () => ({
@@ -158,7 +159,7 @@ describe('ReservationsService', () => {
     it('예약을 성공적으로 취소한다', async () => {
       const txMock = createTxMock();
       const reservationId = 1;
-      const mockSlot = { id: 1, maxCapacity: 10, version: 1 };
+      const mockSlot = { id: 1, eventId: 1, maxCapacity: 10, version: 1 };
       const mockReservation = {
         id: reservationId,
         userId,

--- a/backend/src/reservations/reservations.service.ts
+++ b/backend/src/reservations/reservations.service.ts
@@ -119,9 +119,10 @@ export class ReservationsService {
 
     // Queue에 Job 추가
     await this.reservationQueue.add(PROCESS_RESERVATION_JOB, {
-      reservationId: reservation.id, // 추가
+      reservationId: reservation.id,
       userId,
       slotId: dto.slotId,
+      eventId: slot.event.id,
       maxCapacity: slot.maxCapacity,
       stockDeducted: true,
       groupNumber:
@@ -378,6 +379,7 @@ export class ReservationsService {
         return {
           reservation: updatedReservation,
           slotId: reservation.slotId,
+          eventId: reservation.slot.eventId,
           maxCapacity: reservation.slot.maxCapacity,
         };
       });
@@ -388,6 +390,9 @@ export class ReservationsService {
         result.maxCapacity,
         'cancellation',
       );
+
+      // 예약자 명단 캐시 무효화
+      await this.redisService.invalidateReserversCache(result.eventId);
 
       // 메트릭 기록
       this.metricsService.recordReservation(result.slotId, 'cancelled');

--- a/backend/src/reservations/reservations.service.ts
+++ b/backend/src/reservations/reservations.service.ts
@@ -104,30 +104,40 @@ export class ReservationsService {
       throw new SlotFullException();
     }
 
-    // PENDING 레코드 먼저 생성
-    const reservation = await this.prisma.reservation.create({
-      data: {
+    // Redis 차감 이후 실패 시 재고를 복구하기 위한 보상 트랜잭션
+    try {
+      const reservation = await this.prisma.reservation.create({
+        data: {
+          userId,
+          slotId: dto.slotId,
+          status: 'PENDING',
+          groupNumber:
+            slot.event.applicationUnit === 'TEAM'
+              ? eligibility.groupNumber
+              : null,
+        },
+      });
+
+      await this.reservationQueue.add(PROCESS_RESERVATION_JOB, {
+        reservationId: reservation.id,
         userId,
         slotId: dto.slotId,
-        status: 'PENDING',
+        eventId: slot.event.id,
+        maxCapacity: slot.maxCapacity,
+        stockDeducted: true,
         groupNumber:
           slot.event.applicationUnit === 'TEAM'
             ? eligibility.groupNumber
             : null,
-      },
-    });
-
-    // Queue에 Job 추가
-    await this.reservationQueue.add(PROCESS_RESERVATION_JOB, {
-      reservationId: reservation.id,
-      userId,
-      slotId: dto.slotId,
-      eventId: slot.event.id,
-      maxCapacity: slot.maxCapacity,
-      stockDeducted: true,
-      groupNumber:
-        slot.event.applicationUnit === 'TEAM' ? eligibility.groupNumber : null,
-    });
+      });
+    } catch (error) {
+      await this.redisService.incrementStock(
+        dto.slotId,
+        slot.maxCapacity,
+        'failure_recovery',
+      );
+      throw error;
+    }
 
     // 메트릭 기록
     this.metricsService.recordReservation(dto.slotId, 'pending');


### PR DESCRIPTION
## PR 타입
- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  UI 변경(스타일 파일 추가 및 수정 등)
- [ ]  문서 작성 및 수정
- [x]  테스트 코드 추가
- [ ]  코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [x]  기타 (설정 추가 등)


## 작업 내역

### 스키마 수정했습니다!

- [x]  DB 폴링 부하 제거
- [x] `apply()`에서 Redis 재고 차감 후 DB/Queue 실패 시 보상 트랜잭션 추가
- [x] 빈번한 쿼리 패턴에 대한 복합 인덱스 추가

## 주요 고민과 해결 과정

### 1. 실시간 정원 폴링의 DB 부하 문제
이벤트 상세 페이지 진입 시 1초 간격으로 폴링되는데, 이 때 DB에 접근하는 쿼리 2 ~ 3개를 실행하고 있었습니다.
-> 동시 접속자가 N명이면 초당 2N ~ 3N개의 DB 쿼리가 발생

이 때 데이터가 자주 변하는 것(현재 인원수)과 거의 안 변하는 것(예약자 명단 등의 메타데이터)으로 나뉘는데 현재 인원수는 이미 Redis에서 키로 처리하고 있었기에, 명단만 Redis에 캐시하고, 인원수는 기존 stock 키를 그대로 활용했습니다

- 캐시 HIT 시 **DB 쿼리 0개** → 동시 접속자 수와 무관하게 DB 부하가 일정하게 유지됩니다.

### 2. 예약 프로세스의 Race Condition
현재 예약 프로세스의 흐름은 ① Redis 재고 차감 → ② DB에 PENDING 예약 생성 → ③ BullMQ 작업 추가 순서로 진행됩니다. 

그런데 ①이 성공한 뒤 ②나 ③에서 예외가 발생하면, Redis 재고는 차감된 채로 남지만 실제 예약은 생성되지 않아 좌석 1개가 증발할 수도 있는 상태였습니다.

-> ① 이후의 ②③ 작업에 예외를 추가하고 보상 트랜잭션을 도입해 손실을 방지했습니다.

```typescript
// Redis 재고 차감
const success = await this.redisService.decrementStock(dto.slotId);

try {
  // DB + Queue 작업
  const reservation = await this.prisma.reservation.create({ ... });
  await this.reservationQueue.add(PROCESS_RESERVATION_JOB, { ... });
} catch (error) {
  // 실패 시 Redis 재고 복구
  await this.redisService.incrementStock(dto.slotId, slot.maxCapacity, 'failure_recovery');
  throw error;
}
```

### 3. 누락된 복합 인덱스 추가

- `Reservation(slotId, status)`: 예약 확정 처리(Processor)에서 `WHERE slotId = ? AND status = 'CONFIRMED'` 조건으로 빈번하게 조회
- `Event(organizationId, track)`: 이벤트 목록 필터링 시 조직 + 트랙 조건으로 조회
